### PR TITLE
Refactoring datacheck service

### DIFF
--- a/ensembl/datacheck/app.py
+++ b/ensembl/datacheck/app.py
@@ -26,318 +26,323 @@ CORS(app)
 
 Swagger(app, template_file='swagger.yml')
 
-
 app.analysis = app.config['HIVE_ANALYSIS']
 app.index = json.load(open(app.config['DATACHECK_INDEX']))
 app.server_uris = json.load(open(os.path.join(app_path, app.config['SERVER_URIS_FILE'])))
 
-
 app.names_list = []
 
+
 def get_names_list():
-  if not app.names_list:
-    for name, params in app.index.items():
-      app.names_list.append(name)
-    app.names_list.sort()
-  return app.names_list
+    if not app.names_list:
+        for name, params in app.index.items():
+            app.names_list.append(name)
+        app.names_list.sort()
+    return app.names_list
 
 
 app.groups_list = []
 
+
 def get_groups_list():
-  if not app.groups_list:
-    groups_list = []
-    for name, params in app.index.items():
-      for group in params['groups']:
-        groups_list.append(group)
-    app.groups_list = sorted(set(groups_list))
-  return app.groups_list
+    if not app.groups_list:
+        groups_set = []
+        for name, params in app.index.items():
+            for group in params['groups']:
+                groups_set.append(group)
+        app.groups_list = sorted(set(groups_set))
+    return app.groups_list
 
 
 app.servers_list = []
 
+
 def get_servers_list():
-  if not app.servers_list:
-    servers_list = app.server_uris
-    app.servers_list = sorted(set(servers_list))
-  return app.servers_list
+    if not app.servers_list:
+        app.servers_list = sorted(set(app.server_uris))
+    return app.servers_list
 
 
 hive = None
 
+
 def get_hive(hive_server='vertebrates'):
-  global hive
-  if hive is None:
-    if hive_server == 'vertebrates':
-      hive = HiveInstance(app.config['HIVE_VERT_URI'])
-    elif hive_server == 'non_vertebrates':
-      hive = HiveInstance(app.config['HIVE_NONVERT_URI'])
-    else:
-      raise RuntimeError('Unrecognised Pipeline Server: %s' % hive_server)
-  return hive
+    global hive
+    if hive is None:
+        if hive_server == 'vertebrates':
+            hive = HiveInstance(app.config['HIVE_VERT_URI'])
+        elif hive_server == 'non_vertebrates':
+            hive = HiveInstance(app.config['HIVE_NONVERT_URI'])
+        else:
+            raise RuntimeError('Unrecognised Pipeline Server: %s' % hive_server)
+    return hive
 
 
 @app.route('/datacheck/', methods=['GET'])
 def index():
-  return render_template('ensembl/datacheck/index.html')
+    return render_template('ensembl/datacheck/index.html')
 
 
 @app.route('/datacheck/servers/list', methods=['GET'])
 def servers_list():
-  return jsonify(get_servers_list())
+    return jsonify(get_servers_list())
+
 
 @app.route('/datacheck/databases/list', methods=['GET'])
 def databases_list():
-  db_uri = request.args.get('db_uri')
-  query = request.args.get('query')
-  return jsonify(get_databases_list(db_uri, query))
+    db_uri = request.args.get('db_uri')
+    query = request.args.get('query')
+    return jsonify(get_databases_list(db_uri, query))
 
 
 @app.route('/datacheck/names/', methods=['GET'])
 @app.route('/datacheck/names/<string:name_param>', methods=['GET'])
 def names(name_param=None):
-  if name_param is None:
-    index_names = app.index
-  else:
-    index_names = {}
-    for name, params in app.index.items():
-      if name == name_param:
-        index_names.setdefault(name,[]).append(params)
+    if name_param is None:
+        index_names = app.index
+    else:
+        index_names = {}
+        for name, params in app.index.items():
+            if name == name_param:
+                index_names.setdefault(name, []).append(params)
 
-  if request.is_json:
-    return jsonify(index_names)
-  else:
-    return render_template(
-      'ensembl/datacheck/names.html',
-      datachecks = index_names
-    )
+    if request.is_json:
+        return jsonify(index_names)
+    else:
+        return render_template(
+            'ensembl/datacheck/names.html',
+            datachecks=index_names
+        )
+
 
 @app.route('/datacheck/names/list', methods=['GET'])
 def names_list():
-  return jsonify(get_names_list())
+    return jsonify(get_names_list())
 
 
 @app.route('/datacheck/groups/', methods=['GET'])
 @app.route('/datacheck/groups/<string:group_param>', methods=['GET'])
 def groups(group_param=None):
-  index_groups = {}
-  for name, params in app.index.items():
-    for group in params['groups']:
-      if group_param is None or group == group_param:
-        index_groups.setdefault(group,[]).append(params)
+    index_groups = {}
+    for name, params in app.index.items():
+        for group in params['groups']:
+            if group_param is None or group == group_param:
+                index_groups.setdefault(group, []).append(params)
 
-  if request.is_json:
-    return jsonify(index_groups)
-  else:
-    return render_template(
-      'ensembl/datacheck/groups.html',
-      datachecks = index_groups
-    )
+    if request.is_json:
+        return jsonify(index_groups)
+    else:
+        return render_template(
+            'ensembl/datacheck/groups.html',
+            datachecks=index_groups
+        )
+
 
 @app.route('/datacheck/groups/list', methods=['GET'])
 def groups_list():
-  return jsonify(get_groups_list())
+    return jsonify(get_groups_list())
 
 
 @app.route('/datacheck/types/', methods=['GET'])
 @app.route('/datacheck/types/<string:type_param>', methods=['GET'])
 def types(type_param=None):
-  index_types = {}
-  for name, params in app.index.items():
-    if type_param is None or params['datacheck_type'] == type_param:
-      index_types.setdefault(params['datacheck_type'],[]).append(params)
+    index_types = {}
+    for name, params in app.index.items():
+        if type_param is None or params['datacheck_type'] == type_param:
+            index_types.setdefault(params['datacheck_type'], []).append(params)
 
-  if request.is_json:
-    return jsonify(index_types)
-  else:
-    return render_template(
-      'ensembl/datacheck/types.html',
-      datachecks = index_types
-    )
+    if request.is_json:
+        return jsonify(index_types)
+    else:
+        return render_template(
+            'ensembl/datacheck/types.html',
+            datachecks=index_types
+        )
 
 
 @app.route('/datacheck/search/<string:keyword>', methods=['GET'])
 def search(keyword):
-  index_search = {}
-  keyword_re = re.compile(keyword, re.IGNORECASE)
+    index_search = {}
+    keyword_re = re.compile(keyword, re.IGNORECASE)
 
-  for name, params in app.index.items():
-    if keyword_re.search(name) or keyword_re.search(params['description']):
-        index_search.setdefault(keyword,[]).append(params)
+    for name, params in app.index.items():
+        if keyword_re.search(name) or keyword_re.search(params['description']):
+            index_search.setdefault(keyword, []).append(params)
 
-  return jsonify(index_search)
+    return jsonify(index_search)
 
 
 @app.route('/datacheck/jobs', methods=['POST'])
-def job_submit(payload = None):
-  # Most of the parameters that are in the payload can be pushed straight
-  # through to the input_data for the hive submission. The parameter names
-  # have been made to match up nicely. However, there are a few input
-  # parameters that need to be derived from the payload ones, and once that's
-  # done we remove them from the input dictionary.
-  if payload is None:
-    payload = request.json
+def job_submit(payload=None):
+    # Most of the parameters that are in the payload can be pushed straight
+    # through to the input_data for the hive submission. The parameter names
+    # have been made to match up nicely. However, there are a few input
+    # parameters that need to be derived from the payload ones, and once that's
+    # done we remove them from the input dictionary.
+    if payload is None:
+        payload = request.json
 
-  input_data = dict(payload)
+    input_data = dict(payload)
 
-  if payload['database']:
-    input_data['run_all'] = 1
+    if payload['database']:
+        input_data['run_all'] = 1
 
-  # Hard-code this for the time being; need to handle memory usage better for unparallelised runs
-  input_data['parallelize_datachecks'] = 1
+    # Hard-code this for the time being; need to handle memory usage better for unparallelised runs
+    input_data['parallelize_datachecks'] = 1
 
-  input_data['registry_file'] = set_registry_file(payload)
+    input_data['registry_file'] = set_registry_file(payload)
 
-  input_data['config_file'] = set_config_file(payload)
+    input_data['config_file'] = set_config_file(payload)
 
-  del input_data['server_url']
-  del input_data['database']
-  del input_data['release']
-  del input_data['config_profile']
+    del input_data['server_url']
+    del input_data['database']
+    del input_data['release']
+    del input_data['config_profile']
 
-  print(input_data)
+    print(input_data)
 
-  hive_server = 'vertebrates'
-  if payload['config_profile'] != 'vertebrates':
-    hive_server = 'non_vertebrates'
+    hive_server = 'vertebrates'
+    if payload['config_profile'] != 'vertebrates':
+        hive_server = 'non_vertebrates'
 
-  job = get_hive(hive_server).create_job(app.analysis, input_data)
+    job = get_hive(hive_server).create_job(app.analysis, input_data)
 
-  if request.is_json:
-    results = {"job_id": job.job_id}
-    return jsonify(results), 201
-  else:
-    return redirect('/datacheck/jobs/' + str(job.job_id))
+    if request.is_json:
+        results = {"job_id": job.job_id}
+        return jsonify(results), 201
+    else:
+        return redirect('/datacheck/jobs/' + str(job.job_id))
 
 
 @app.route('/datacheck/jobs', methods=['GET'])
 def job_list():
-  jobs = get_hive().get_all_results(app.analysis, child=True)
+    jobs = get_hive().get_all_results(app.analysis, child=True)
 
-  # Handle case where submission is marked as complete,
-  # but where output has not been created.
-  for job in jobs:
-    if job['status'] == 'complete' and 'output' not in job.keys():
-      job['status'] = 'incomplete'
+    # Handle case where submission is marked as complete,
+    # but where output has not been created.
+    for job in jobs:
+        if job['status'] == 'complete' and 'output' not in job.keys():
+            job['status'] = 'incomplete'
 
-  #if request.is_json:
-  return jsonify(jobs)
-  #else:
+    # if request.is_json:
+    return jsonify(jobs)
+    # else:
     # Need to pass some data to the template...
-    #return render_template('ensembl/datacheck/list.html')
+    # return render_template('ensembl/datacheck/list.html')
 
 
 @app.route('/datacheck/jobs/<int:job_id>', methods=['GET'])
 def job_result(job_id):
-  job = get_hive().get_result_for_job_id(job_id, child=True, progress=False)
+    job = get_hive().get_result_for_job_id(job_id, child=True, progress=False)
 
-  # Handle case where submission is marked as complete,
-  # but where output has not been created.
-  if job['status'] == 'complete' and 'output' not in job.keys():
-    job['status'] = 'incomplete'
+    # Handle case where submission is marked as complete,
+    # but where output has not been created.
+    if job['status'] == 'complete' and 'output' not in job.keys():
+        job['status'] = 'incomplete'
 
-  #if request.is_json:
-  return jsonify(job)
-  #else:
+    # if request.is_json:
+    return jsonify(job)
+    # else:
     # Need to pass some data to the template...
-    #return render_template('ensembl/datacheck/detail.html')
+    # return render_template('ensembl/datacheck/detail.html')
 
 
 @app.route('/datacheck/submit', methods=['GET'])
 def display_form():
-  form = DatacheckSubmissionForm(request.form)
+    form = DatacheckSubmissionForm(request.form)
 
-  return render_template(
-    'ensembl/datacheck/submit.html',
-    form = form
-  )
+    return render_template(
+        'ensembl/datacheck/submit.html',
+        form=form
+    )
 
 
 @app.route('/datacheck/submit', methods=['POST'])
 def submit_form():
-  # Here we convert the form fields into a 'payload' dictionary
-  # that is the required input format for the hive submission.
+    # Here we convert the form fields into a 'payload' dictionary
+    # that is the required input format for the hive submission.
 
-  form = DatacheckSubmissionForm(request.form)
+    form = DatacheckSubmissionForm(request.form)
 
-  payload = {
-    'server_url': form.server.server_url.data,
-    'database': None,
-    'species': None,
-    'division': None,
-    'db_type': None,
-    'release': None,
-    'datacheck_names':[],
-    'datacheck_groups': [],
-    'datacheck_types': [],
-    'config_profile': form.configuration.config_profile.data,
-    'email': form.configuration.email.data,
-    'tag': form.configuration.tag.data
-  }
+    payload = {
+        'server_url': form.server.server_url.data,
+        'database': None,
+        'species': None,
+        'division': None,
+        'db_type': None,
+        'release': None,
+        'datacheck_names': [],
+        'datacheck_groups': [],
+        'datacheck_types': [],
+        'config_profile': form.configuration.config_profile.data,
+        'email': form.configuration.email.data,
+        'tag': form.configuration.tag.data
+    }
 
-  if form.server.source.data == 'database':
-    payload['database'] = form.server.database.data
-  else:
-    if form.server.source.data == 'species':
-      payload['species'] = form.server.species.data.split(',')
-    elif form.server.source.data == 'division':
-      payload['division'] = form.server.division.data.split(',')
+    if form.server.source.data == 'database':
+        payload['database'] = form.server.database.data
+    else:
+        if form.server.source.data == 'species':
+            payload['species'] = form.server.species.data.split(',')
+        elif form.server.source.data == 'division':
+            payload['division'] = form.server.division.data.split(',')
 
-    payload['db_type'] = form.server.database_type.data
-    payload['release'] = dict(form.server.release.choices).get(form.server.release.data)
+        payload['db_type'] = form.server.database_type.data
+        payload['release'] = dict(form.server.release.choices).get(form.server.release.data)
 
-  if form.datacheck.datacheck_name.data != '':
-    payload['datacheck_names'] = form.datacheck.datacheck_name.data.split(',')
-  if form.datacheck.datacheck_group.data != '':
-    payload['datacheck_groups'] = form.datacheck.datacheck_group.data.split(',')
-  if form.datacheck.datacheck_type.data != '':
-    payload['datacheck_types'] = form.datacheck.datacheck_type.data.split(',')
+    if form.datacheck.datacheck_name.data != '':
+        payload['datacheck_names'] = form.datacheck.datacheck_name.data.split(',')
+    if form.datacheck.datacheck_group.data != '':
+        payload['datacheck_groups'] = form.datacheck.datacheck_group.data.split(',')
+    if form.datacheck.datacheck_type.data != '':
+        payload['datacheck_types'] = form.datacheck.datacheck_type.data.split(',')
 
-  return job_submit(payload)
+    return job_submit(payload)
 
 
 @app.route('/datacheck/ping', methods=['GET'])
 def ping():
-  return jsonify({'status': 'ok'})
+    return jsonify({'status': 'ok'})
 
 
 def set_registry_file(params):
-  # We need to create a registry file that knows where the metadata and
-  # production db are, because some datachecks need them; so we read those in from a file.
-  # We then need to work out whether we're connecting to a specific database,
-  # or a server with species/division parameters, and add the appropriate stanza.
+    # We need to create a registry file that knows where the metadata and
+    # production db are, because some datachecks need them; so we read those in from a file.
+    # We then need to work out whether we're connecting to a specific database,
+    # or a server with species/division parameters, and add the appropriate stanza.
 
-  # Note that we don't need to check server_url format here,
-  # both the client script and web page perform validation.
+    # Note that we don't need to check server_url format here,
+    # both the client script and web page perform validation.
 
-  meta_db_file = open(app.config['DATACHECK_REGISTRY_META'], 'r')
-  meta_db_text = meta_db_file.read()
-  meta_db_file.close()
+    meta_db_file = open(app.config['DATACHECK_REGISTRY_META'], 'r')
+    meta_db_text = meta_db_file.read()
+    meta_db_file.close()
 
-  db_url = None
-  if params['database']:
-    if not params['db_type']:
-      if 'compara' in params['database']:
-        params['db_type'] = 'compara'
-      else:
-        m = re.match(r'.+\_([a-z]+)', params['database'])
-        params['db_type'] = m.group(1)
-    db_url = os.path.join(params['server_url'], params['database'], '?group=' + params['db_type'])
-  elif params['species'] or params['division']:
-    db_url = params['server_url']
-    if params['release']:
-      db_url = os.path.join(db_url, params['release'])
+    db_url = None
+    if params['database']:
+        if not params['db_type']:
+            if 'compara' in params['database']:
+                params['db_type'] = 'compara'
+            else:
+                m = re.match(r'.+_([a-z]+)', params['database'])
+                params['db_type'] = m.group(1)
+        db_url = os.path.join(params['server_url'], params['database'], '?group=' + params['db_type'])
+    elif params['species'] or params['division']:
+        db_url = params['server_url']
+        if params['release']:
+            db_url = os.path.join(db_url, params['release'])
 
-  timestamp = str(int(time.time()))
-  registry_path = os.path.join(app.config['DATACHECK_REGISTRY_DIR'], '_'.join([timestamp, 'registry.pm']))
+    timestamp = str(int(time.time()))
+    registry_path = os.path.join(app.config['DATACHECK_REGISTRY_DIR'], '_'.join([timestamp, 'registry.pm']))
 
-  registry_file = open(registry_path, 'x')
-  registry_file.write(meta_db_text)
-  registry_file.write("Bio::EnsEMBL::Registry->load_registry_from_url('" + db_url + "');\n")
-  registry_file.write('1;\n')
-  registry_file.close()
+    registry_file = open(registry_path, 'x')
+    registry_file.write(meta_db_text)
+    registry_file.write("Bio::EnsEMBL::Registry->load_registry_from_url('" + db_url + "');\n")
+    registry_file.write('1;\n')
+    registry_file.close()
 
-  return registry_path
+    return registry_path
+
 
 def set_config_file(params):
-  return os.path.join(app.config['DATACHECK_CONFIG_DIR'], '.'.join([params['config_profile'], 'json']))
+    return os.path.join(app.config['DATACHECK_CONFIG_DIR'], '.'.join([params['config_profile'], 'json']))

--- a/ensembl/datacheck/app.py
+++ b/ensembl/datacheck/app.py
@@ -212,7 +212,7 @@ def job_submit(payload = None):
 
 @app.route('/datacheck/jobs', methods=['GET'])
 def job_list():
-  jobs = get_hive().get_all_results(app.analysis)
+  jobs = get_hive().get_all_results(app.analysis, child=True)
 
   # Handle case where submission is marked as complete,
   # but where output has not been created.
@@ -229,7 +229,7 @@ def job_list():
 
 @app.route('/datacheck/jobs/<int:job_id>', methods=['GET'])
 def job_result(job_id):
-  job = get_hive().get_result_for_job_id(job_id, progress=False)
+  job = get_hive().get_result_for_job_id(job_id, child=True, progress=False)
 
   # Handle case where submission is marked as complete,
   # but where output has not been created.

--- a/ensembl/datacheck/app.py
+++ b/ensembl/datacheck/app.py
@@ -194,7 +194,7 @@ def job_submit(payload=None):
     if input_data['dbname'] is not None:
         db_uri = input_data['server_url'] + input_data['dbname']
         assert_mysql_db_uri(db_uri)
-        input_data['db_type'] = get_db_type(db_uri)
+        input_data['db_type'] = set_db_type(input_data['dbname'], db_uri)
         input_data['dbname'] = input_data['dbname'].split(',')
     elif input_data['species'] is not None:
         input_data['species'] = input_data['species'].split(',')
@@ -317,6 +317,15 @@ def submit_form():
 def ping():
     return jsonify({'status': 'ok'})
 
+
+def set_db_type(dbname, db_uri):
+    p = re.compile('cdna|otherfeatures|rnaseq')
+    m = p.search(dbname)
+    if m is not None:
+        db_type = m.group()
+    else:
+        db_type = get_db_type(db_uri)
+    return db_type
 
 def set_registry_file(db_type, server_name):
     return os.path.join(app.config['DATACHECK_REGISTRY_DIR'], db_type, '.'.join([server_name, 'pm']))

--- a/ensembl/datacheck/config.py
+++ b/ensembl/datacheck/config.py
@@ -13,8 +13,7 @@ class DatacheckConfig(EnsemblConfig):
                                           file_config.get('datacheck_common_dir'))
     DATACHECK_CONFIG_DIR = os.path.join(DATACHECK_COMMON_DIR, 'config')
     DATACHECK_REGISTRY_DIR = os.path.join(DATACHECK_COMMON_DIR, 'registry')
-    DATACHECK_REGISTRY_META = os.path.join(DATACHECK_REGISTRY_DIR, 'registry_meta.pm')
     HIVE_ANALYSIS = os.environ.get("HIVE_ANALYSIS",
                                    file_config.get('hive_analysis', 'DataCheckSubmission'))
-    HIVE_VERT_URI = os.environ.get("HIVE_VERT_URI", file_config.get('hive_vert_uri'))
-    HIVE_NONVERT_URI = os.environ.get("HIVE_NONVERT_URI", file_config.get('hive_nonvert_uri'))
+    HIVE_URI = os.environ.get("HIVE_URI", file_config.get('hive_uri'))
+    SERVER_NAMES_FILE = os.environ.get("SERVER_NAMES", file_config.get('server_names_file'))

--- a/ensembl/forms.py
+++ b/ensembl/forms.py
@@ -20,11 +20,10 @@ database_types = [
     ('variation', 'variation')
 ]
 
-# Dynamically populate the versions
-releases = [
-    ('master', '99'),
-    ('active', '98'),
-    ('live', '97')
+datacheck_types = [
+    ('', 'critical and advisory'),
+    ('critical', 'critical'),
+    ('advisory', 'advisory')
 ]
 
 
@@ -64,32 +63,29 @@ class AtLeastOne(object):
 
 
 class ServerForm(Form):
-    server_url = StringField('Server URL', validators=[InputRequired()])
-    source = SelectField('Source', choices=[('database', 'Database'), ('species', 'Species'), ('division', 'Division')])
-    database = StringField('Database')
-    species = StringField('Species')
-    division = SelectField('Division', choices=divisions)
-    database_type = SelectField('Database Type', choices=database_types, default='core')
-    release = SelectField('Release', choices=releases, default='active')
+    server_name = SelectField('Server Name', validators=[InputRequired()])
+    source = SelectField('Source', choices=[('dbname', 'Database'), ('species', 'Species'), ('division', 'Division')])
+    dbname = StringField('Database', validators=[AtLeastOne(['species', 'division'])])
+    species = StringField('Species', validators=[AtLeastOne(['database', 'division'])])
+    division = SelectField('Division', choices=divisions, validators=[AtLeastOne(['database', 'species'])], default='vertebrates')
+    db_type = SelectField('Database Type', choices=database_types, default='core')
 
 
 class DatacheckForm(Form):
-    datacheck_name = StringField('Names')
-    datacheck_group = StringField('Groups')
-    datacheck_type = SelectField('Type', choices=[('', 'critical and advisory'), ('critical', 'critical'),
-                                                  ('advisory', 'advisory')])
+    datacheck_name = StringField('Names', validators=[AtLeastOne(['datacheck_name'])])
+    datacheck_group = StringField('Groups', validators=[AtLeastOne(['datacheck_group'])])
+    datacheck_type = SelectField('Type', choices=datacheck_types, default='critical')
 
 
-class ConfigurationForm(Form):
-    config_profile = SelectField('Profile', choices=divisions)
-    email = StringField('Email', validators=[Email()])
+class SubmitterForm(Form):
+    email = StringField('Email', validators=[Email(), InputRequired()])
     tag = StringField('Tag')
 
 
 class DatacheckSubmissionForm(Form):
     server = FormField(ServerForm, description='Server')
     datacheck = FormField(DatacheckForm, description='Datachecks')
-    configuration = FormField(ConfigurationForm, description='Configuration')
+    submitter = FormField(SubmitterForm, description='Submitter')
     submit = SubmitField('Submit')
 
 

--- a/server_names.json.example
+++ b/server_names.json.example
@@ -1,0 +1,3 @@
+{
+  "local": "vertebrates"
+}

--- a/server_names.json.example
+++ b/server_names.json.example
@@ -1,3 +1,6 @@
 {
-  "local": "vertebrates"
+  "mysql://ensro@localhost:3306/": {
+    "server_name": "localhost",
+    "config_profile": "local"
+  }
 }

--- a/server_uris_list.json.example
+++ b/server_uris_list.json.example
@@ -1,3 +1,0 @@
-[
-  "mysql://ensro@localhost:3306/"
-]

--- a/static/autocomplete.js
+++ b/static/autocomplete.js
@@ -44,20 +44,6 @@ $(document).ready(function(){
         }
     });
 
-    var datacheck_server_list = new Bloodhound({
-        datumTokenizer: Bloodhound.tokenizers.whitespace,
-        queryTokenizer: Bloodhound.tokenizers.whitespace,
-        prefetch: 'servers/list'
-    });
-
-    $('#server-server_url').tagsinput({
-        typeaheadjs: {
-            highlight: true,
-            name: 'datacheck_server_list',
-            source: datacheck_server_list
-        }
-    });
-
     var datacheck_database_list = new Bloodhound({
         datumTokenizer: Bloodhound.tokenizers.whitespace,
         queryTokenizer: Bloodhound.tokenizers.whitespace

--- a/static/ensembl.js
+++ b/static/ensembl.js
@@ -1,48 +1,43 @@
 function selectServerSource() {
-  var server_source = document.getElementById('server-source').value;
+  const server_source = document.getElementById('server-source').value;
 
-  if (server_source == 'database') {
-    databaseDisplay('block');
+  if (server_source === 'dbname') {
+    dbnameDisplay('block');
     speciesDisplay('none');
     divisionDisplay('none');
-    releaseDisplay('none');
+    db_typeDisplay('none');
 
-  } else if (server_source == 'species') {
-    databaseDisplay('none');
+  } else if (server_source === 'species') {
+    dbnameDisplay('none');
     speciesDisplay('block');
     divisionDisplay('none');
-    releaseDisplay('block');
+    db_typeDisplay('block');
 
-  } else if (server_source == 'division') {
-    databaseDisplay('none');
+  } else if (server_source === 'division') {
+    dbnameDisplay('none');
     speciesDisplay('none');
     divisionDisplay('block');
-    releaseDisplay('block');
+    db_typeDisplay('block');
 
   }
 }
 
-function selectDivision() {
-  var division = document.getElementById('server-division').value;
+function dbnameDisplay(display_value) {
+  document.getElementById('server-dbname').style.display = display_value;
 
-  document.getElementById('configuration-config_profile').value = division;
-}
-
-function databaseDisplay(display_value) {
-  document.getElementById('server-database').style.display = display_value;
 }
 
 function speciesDisplay(display_value) {
   document.getElementById('server-species').style.display = display_value;
+
 }
 
 function divisionDisplay(display_value) {
   document.getElementById('server-division').style.display = display_value;
+
 }
 
-function releaseDisplay(display_value) {
-  document.getElementById('server-database_type').style.display = display_value;
-  document.getElementById('server-database_type-label').style.display = display_value;
-  document.getElementById('server-release').style.display = display_value;
-  document.getElementById('server-release-label').style.display = display_value;
+function db_typeDisplay(display_value) {
+  document.getElementById('server-db_type').style.display = display_value;
+  document.getElementById('server-db_type-label').style.display = display_value;
 }

--- a/templates/ensembl/datacheck/submit.html
+++ b/templates/ensembl/datacheck/submit.html
@@ -1,6 +1,7 @@
 
 {% extends "ensembl/submit.html" %}
 
+{% set icon_image = 'img/production.png' %}
 {% set title = 'Datacheck Submission' %}
 
 {% block submit -%}
@@ -12,24 +13,22 @@
       <legend class="w-auto fg-purple">&nbsp;{{ form.server.description }}&nbsp;</legend>
 
       <div class="form-group row">
-        {{ form.server.server_url.label( class='col-sm-2 col-form-label' ) }}
-        <div class="col-sm-9">{{ form.server.server_url( class='form-control' ) }}</div>
+        {{ form.server.server_name.label( class='col-sm-2 col-form-label' ) }}
+        <div class="col-sm-4">{{ form.server.server_name( class='form-control' ) }}</div>
       </div>
 
       <div class="form-group row">
         <div class="col-sm-2">{{ form.server.source( class='form-control select-align-right', onchange='selectServerSource()' ) }}</div>
-        <div class="col-sm-9">
-          {{ form.server.database( class='form-control' ) }}
+        <div class="col-sm-4">
+          {{ form.server.dbname( class='form-control' ) }}
           {{ form.server.species( class='form-control', style='display: none' ) }}
-          {{ form.server.division( class='form-control', onchange='selectDivision()', style='display: none' ) }}
+          {{ form.server.division( class='form-control', style='display: none' ) }}
         </div>
       </div>
 
       <div class="form-group row">
-        {{ form.server.database_type.label( class='col-sm-2 col-form-label', id='server-database_type-label', style='display: none' ) }}
-        <div class="col-sm-2">{{ form.server.database_type( class='form-control', style='display: none' ) }}</div>
-        {{ form.server.release.label( class='col-sm-1 col-form-label', id='server-release-label', style='display: none' ) }}
-        <div class="col-sm-2">{{ form.server.release( class='form-control', style='display: none' ) }}</div>
+        {{ form.server.db_type.label( class='col-sm-2 col-form-label', id='server-db_type-label', style='display: none' ) }}
+        <div class="col-sm-2">{{ form.server.db_type( class='form-control', style='display: none' ) }}</div>
       </div>
 
     </fieldset>
@@ -55,21 +54,16 @@
     </fieldset>
 
     <fieldset class="border rounded p-2">
-      <legend class="w-auto">&nbsp;{{ form.configuration.description }}&nbsp;</legend>
+      <legend class="w-auto">&nbsp;{{ form.submitter.description }}&nbsp;</legend>
 
       <div class="form-group row">
-        {{ form.configuration.config_profile.label( class='col-sm-2 col-form-label' ) }}
-        <div class="col-sm-3">{{ form.configuration.config_profile( class='form-control' ) }}</div>
+        {{ form.submitter.email.label( class='col-sm-2 col-form-label' ) }}
+        <div class="col-sm-5">{{ form.submitter.email( class='form-control' ) }}</div>
       </div>
 
       <div class="form-group row">
-        {{ form.configuration.email.label( class='col-sm-2 col-form-label' ) }}
-        <div class="col-sm-5">{{ form.configuration.email( class='form-control' ) }}</div>
-      </div>
-
-      <div class="form-group row">
-        {{ form.configuration.tag.label( class='col-sm-2 col-form-label' ) }}
-        <div class="col-sm-5">{{ form.configuration.tag( class='form-control' ) }}</div>
+        {{ form.submitter.tag.label( class='col-sm-2 col-form-label' ) }}
+        <div class="col-sm-5">{{ form.submitter.tag( class='form-control' ) }}</div>
       </div>
 
     </fieldset>


### PR DESCRIPTION
Refactoring the datacheck service in order to fix some bugs and rationalise the code.

Re-think registry management - rather than create on the fly, point to a set of centrally maintained registries. This simplifies the code and means that we can ensure that the appropriate databases are loaded (e.g. if testing funcgen db, include core and variation dbs on staging). To manage this we need to know the type of db being handed over, so app calls a new method for that, from db_utils. Remove release parameter - it adds a lot of complexity, and it's reasonable for the service to apply to only the current release. Remove config_profile parameter, instead have a profile linked to each server, and just look that up.

All of these changes are intended to fix bugs in the app, but they generally do so by removing flexibility/functionality. That can always be reinstated in the future, if necessary - but note that the run_pipeline.pl script offers all the functionality that was here, plus more. So the service can do most things for most people, and that script is an option for 'power users'.
