### PR TITLE
Add sqlalchemy error handling for handover app

### DIFF
--- a/handover_app.py
+++ b/handover_app.py
@@ -4,6 +4,7 @@ import logging
 import re
 
 from elasticsearch import Elasticsearch, TransportError, NotFoundError
+from sqlalchemy.exc import OperationalError
 from flasgger import Swagger
 from flask import Flask, request, jsonify
 from flask_cors import CORS
@@ -378,3 +379,9 @@ def handle_elastisearch_error(e):
 def handle_bad_request_error(e):
     app.logger.error(str(e))
     return jsonify(error=str(e)), e.status_code
+
+
+@app.errorhandler(OperationalError)
+def handle_sqlalchemy_error(e):
+    app.logger.error(str(e))
+    return jsonify(error=str(e)), 500


### PR DESCRIPTION
- Fix handover web app silently failing when MySQL connection fails (preventing users to retry submitting the same request multiple times causing more exceptions)
- Prevent the worker from being terminated due to the unhandled exception (when `propagate_exceptions` is set)